### PR TITLE
예약 CRUD 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ ext {
 }
 
 dependencies {
+    // Kafka
+    implementation 'org.apache.kafka:kafka-clients:3.5.1'
+    implementation 'org.springframework.kafka:spring-kafka'
+
     // swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     // swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'
 
+    // Jwt
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/src/main/java/com/qring/reservation/application/global/exception/BadRequestException.java
+++ b/src/main/java/com/qring/reservation/application/global/exception/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.qring.reservation.application.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends ReservationException {
+    public BadRequestException(String message) {
+        super(ErrorCode.BAD_REQUEST_ERROR, message);
+    }
+}

--- a/src/main/java/com/qring/reservation/application/global/exception/DuplicateResourceException.java
+++ b/src/main/java/com/qring/reservation/application/global/exception/DuplicateResourceException.java
@@ -1,0 +1,10 @@
+package com.qring.reservation.application.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateResourceException extends ReservationException {
+    public DuplicateResourceException(String message) {
+        super(ErrorCode.DUPLICATE_ERROR, message);
+    }
+}

--- a/src/main/java/com/qring/reservation/application/global/exception/EntityNotFoundException.java
+++ b/src/main/java/com/qring/reservation/application/global/exception/EntityNotFoundException.java
@@ -1,0 +1,10 @@
+package com.qring.reservation.application.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class EntityNotFoundException extends ReservationException {
+    public EntityNotFoundException(String message) {
+        super(ErrorCode.NOT_FOUND_ERROR, message);
+    }
+}

--- a/src/main/java/com/qring/reservation/application/global/exception/ErrorCode.java
+++ b/src/main/java/com/qring/reservation/application/global/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.qring.reservation.application.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    AUTHORITY_ERROR(HttpStatus.FORBIDDEN, 4001), // NOTE : 권한 검증 에러
+    DUPLICATE_ERROR(HttpStatus.BAD_REQUEST, 4002), // NOTE : 중복 검증 에러
+    NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, 4003), // NOTE : 존재하지 않는 객체 에러
+    BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, 4004); // NOTE : 기타 에러
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+}

--- a/src/main/java/com/qring/reservation/application/global/exception/ReservationException.java
+++ b/src/main/java/com/qring/reservation/application/global/exception/ReservationException.java
@@ -1,0 +1,16 @@
+package com.qring.reservation.application.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ReservationException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public ReservationException(ErrorCode errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/qring/reservation/application/global/exception/UnauthorizedAccessException.java
+++ b/src/main/java/com/qring/reservation/application/global/exception/UnauthorizedAccessException.java
@@ -1,0 +1,10 @@
+package com.qring.reservation.application.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedAccessException extends ReservationException {
+    public UnauthorizedAccessException(String message) {
+        super(ErrorCode.AUTHORITY_ERROR, message);
+    }
+}

--- a/src/main/java/com/qring/reservation/application/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/qring/reservation/application/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.qring.reservation.application.global.handler;
+
+import com.qring.reservation.application.global.dto.ResDTO;
+import com.qring.reservation.application.global.exception.ReservationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({ReservationException.class})
+    public ResponseEntity<ResDTO<Object>> ReservationExceptionHandler(ReservationException ex) {
+        return new ResponseEntity<>(
+                ResDTO.builder()
+                        .code(ex.getErrorCode().getCode())
+                        .message(ex.getMessage())
+                        .build(),
+                ex.getErrorCode().getHttpStatus()
+        );
+    }
+}

--- a/src/main/java/com/qring/reservation/application/v1/message/KafkaMessageProducerV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/message/KafkaMessageProducerV1.java
@@ -1,0 +1,9 @@
+package com.qring.reservation.application.v1.message;
+
+import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
+
+public interface KafkaMessageProducerV1 {
+
+    void publishReservationCreateEvent(ReservationPostResDTOV1.ReservationInfo reservationInfo);
+
+}

--- a/src/main/java/com/qring/reservation/application/v1/res/ReservationGetByIdResDTOV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/res/ReservationGetByIdResDTOV1.java
@@ -27,7 +27,7 @@ public class ReservationGetByIdResDTOV1 {
     @AllArgsConstructor
     public static class Reservation {
 
-        private Long reservationId;
+        private Long id;
         private Long userId;
         private Long restaurantId;
         private ReservationStatus status;
@@ -35,7 +35,7 @@ public class ReservationGetByIdResDTOV1 {
 
         public static Reservation from(ReservationEntity reservationEntity) {
             return Reservation.builder()
-                    .reservationId(reservationEntity.getId())
+                    .id(reservationEntity.getId())
                     .userId(reservationEntity.getUserId())
                     .restaurantId(reservationEntity.getRestaurantId())
                     .status(reservationEntity.getStatus())

--- a/src/main/java/com/qring/reservation/application/v1/res/ReservationPostResDTOV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/res/ReservationPostResDTOV1.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class ReservationPostResDTOV1 {
 
     private Reservation reservation;
+    private ReservationInfo reservationInfo;
 
     public static ReservationPostResDTOV1 of(ReservationEntity reservationEntity) {
         return ReservationPostResDTOV1.builder()
@@ -40,6 +41,23 @@ public class ReservationPostResDTOV1 {
                     .restaurantId(reservationEntity.getRestaurantId())
                     .status(reservationEntity.getStatus())
                     .headCount(reservationEntity.getHeadCount())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReservationInfo {
+
+        private Long id;
+        private Long restaurantId;
+
+        public static ReservationInfo from(Long id, Long restaurantId) {
+            return ReservationInfo.builder()
+                    .id(id)
+                    .restaurantId(restaurantId)
                     .build();
         }
     }

--- a/src/main/java/com/qring/reservation/application/v1/res/ReservationSearchResDTOV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/res/ReservationSearchResDTOV1.java
@@ -46,7 +46,7 @@ public class ReservationSearchResDTOV1 {
         @AllArgsConstructor
         public static class Reservation {
 
-            private Long reservationId;
+            private Long id;
             private Long userId;
             private Long restaurantId;
             private ReservationStatus status;
@@ -61,7 +61,7 @@ public class ReservationSearchResDTOV1 {
             public static Reservation from(ReservationEntity reservationEntity) {
 
                 return Reservation.builder()
-                        .reservationId(reservationEntity.getId())
+                        .id(reservationEntity.getId())
                         .userId(reservationEntity.getUserId())
                         .restaurantId(reservationEntity.getRestaurantId())
                         .status(reservationEntity.getStatus())

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -24,4 +24,3 @@ public class ReservationServiceV1 {
         return ReservationPostResDTOV1.of(reservationRepository.save(reservationEntityForSave));
     }
 }
-

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -1,0 +1,27 @@
+package com.qring.reservation.application.v1.service;
+
+import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
+import com.qring.reservation.domain.model.ReservationEntity;
+import com.qring.reservation.domain.repository.ReservationRepository;
+import com.qring.reservation.presentation.v1.req.PostReservationReqDTOV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationServiceV1 {
+
+    private final ReservationRepository reservationRepository;
+
+    public ReservationPostResDTOV1 postBy(Long userId, PostReservationReqDTOV1 dto){
+
+        ReservationEntity reservationEntityForSave = ReservationEntity.createReservationEntity(
+                userId,
+                dto.getReservation().getRestaurantId(),
+                dto.getReservation().getHeadCount()
+        );
+
+        return ReservationPostResDTOV1.of(reservationRepository.save(reservationEntityForSave));
+    }
+}
+

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class ReservationServiceV1 {
@@ -31,6 +34,10 @@ public class ReservationServiceV1 {
     }
 
     private void publishReservationCreateEvent(Long reservationId) {
-        kafkaTemplate.send("reservation-create-event-topic", reservationId);
+
+        Map<String, Object> event = new HashMap<>();
+        event.put("reservationId", reservationId);
+
+        kafkaTemplate.send("reservation-create-event-topic", event);
     }
 }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -29,7 +29,7 @@ public class ReservationServiceV1 {
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Transactional
-    public ReservationPostResDTOV1 postBy(String passport, PostReservationReqDTOV1 dto){
+    public ReservationPostResDTOV1 postBy(String passport, PostReservationReqDTOV1 dto) {
 
         ReservationEntity reservationEntityForSave = ReservationEntity.createReservationEntity(
                 PassportUtil.getUserId(passport),
@@ -55,7 +55,7 @@ public class ReservationServiceV1 {
         String role = PassportUtil.getRole(passport);
         Long userId = PassportUtil.getUserId(passport);
 
-        ReservationEntity reservationEntityForRead = getReservationEntityById(id);
+        ReservationEntity reservationEntityForMapping = getReservationEntityById(id);
 
         Long restaurantId = 1L;
 
@@ -65,12 +65,12 @@ public class ReservationServiceV1 {
                 // 관리자는 모든 예약에 접근 가능
                 break;
             case "고객":
-                if (!reservationEntityForRead.getUserId().equals(userId)) {
+                if (!reservationEntityForMapping.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 조회할 수 있습니다.");
                 }
                 break;
             case "점주":
-                if (!reservationEntityForRead.getRestaurantId().equals(restaurantId)) {
+                if (!reservationEntityForMapping.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 조회할 수 있습니다.");
                 }
                 break;
@@ -78,7 +78,7 @@ public class ReservationServiceV1 {
                 throw new BadRequestException("유효하지 않은 역할입니다: " + role);
         }
 
-        return ReservationGetByIdResDTOV1.of(reservationEntityForRead);
+        return ReservationGetByIdResDTOV1.of(reservationEntityForMapping);
     }
 
     @Transactional(readOnly = true)
@@ -86,7 +86,7 @@ public class ReservationServiceV1 {
 
         String role = PassportUtil.getRole(passport);
 
-        validateRole(role,"관리자");
+        validateUserRole(role, "관리자");
 
         Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
 
@@ -99,7 +99,7 @@ public class ReservationServiceV1 {
         String role = PassportUtil.getRole(passport);
         Long userId = PassportUtil.getUserId(passport);
 
-        validateRole(role,"고객");
+        validateUserRole(role, "고객");
 
         Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
 
@@ -115,7 +115,7 @@ public class ReservationServiceV1 {
         // 점주의 소유 식당 목록 - 구현 예정
         List<Long> restaurantIdListOfOwner = Arrays.asList(1L, 6L);
 
-        validateRole(role,"점주");
+        validateUserRole(role, "점주");
 
         Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithOwnerConditions(pageable, restaurantIdListOfOwner, userId, restaurantId, id, sort);
 
@@ -123,17 +123,17 @@ public class ReservationServiceV1 {
     }
 
     @Transactional
-    public void putBy(String passport, Long id, PutReservationReqDTOV1 dto){
+    public void putBy(String passport, Long id, PutReservationReqDTOV1 dto) {
 
         String role = PassportUtil.getRole(passport);
         Long userId = PassportUtil.getUserId(passport);
 
-        ReservationEntity reservationEntityForUpdate = getReservationEntityById(id);
+        ReservationEntity reservationEntityForModify = getReservationEntityById(id);
 
         Long restaurantId = 1L;
 
         // 예약 상태 확인 (취소 상태인 경우 수정 불가)
-        if (reservationEntityForUpdate.getStatus() == ReservationStatus.CANCELLED) {
+        if (reservationEntityForModify.getStatus() == ReservationStatus.CANCELLED) {
             throw new BadRequestException("이미 취소된 예약입니다.");
         }
 
@@ -143,12 +143,12 @@ public class ReservationServiceV1 {
                 // 관리자는 모든 예약 상태 변경 가능
                 break;
             case "고객":
-                if (!reservationEntityForUpdate.getUserId().equals(userId)) {
+                if (!reservationEntityForModify.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 취소할 수 있습니다.");
                 }
                 break;
             case "점주":
-                if (!reservationEntityForUpdate.getRestaurantId().equals(restaurantId)) {
+                if (!reservationEntityForModify.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 취소할 수 있습니다.");
                 }
                 break;
@@ -156,11 +156,11 @@ public class ReservationServiceV1 {
                 throw new BadRequestException("유효하지 않은 역할입니다: " + role);
         }
 
-        reservationEntityForUpdate.updateReservationEntityStatus(dto.getReservation().getStatus());
+        reservationEntityForModify.updateReservationEntityStatus(dto.getReservation().getStatus());
     }
 
     @Transactional
-    public void deleteBy(String passport, Long id){
+    public void deleteBy(String passport, Long id) {
 
         String role = PassportUtil.getRole(passport);
         Long userId = PassportUtil.getUserId(passport);
@@ -206,9 +206,9 @@ public class ReservationServiceV1 {
     }
 
     // 권한 검증
-    private void validateRole(String role, String requiredRole) {
+    private void validateUserRole(String role, String requiredRole) {
         if (!role.equals(requiredRole)) {
-            throw new UnauthorizedAccessException("올바른 권한이 아닙니다.");
+            throw new UnauthorizedAccessException("접근 권한이 없습니다");
         }
     }
 }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -5,17 +5,21 @@ import com.qring.reservation.application.global.exception.EntityNotFoundExceptio
 import com.qring.reservation.application.global.exception.UnauthorizedAccessException;
 import com.qring.reservation.application.v1.res.ReservationGetByIdResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
+import com.qring.reservation.application.v1.res.ReservationSearchResDTOV1;
 import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.domain.model.constraint.ReservationStatus;
 import com.qring.reservation.domain.repository.ReservationRepository;
 import com.qring.reservation.presentation.v1.req.PostReservationReqDTOV1;
 import com.qring.reservation.presentation.v1.req.PutReservationReqDTOV1;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import java.nio.file.AccessDeniedException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,24 +58,51 @@ public class ReservationServiceV1 {
             case "ADMIN":
                 // 관리자는 모든 예약에 접근 가능
                 break;
-
             case "USER":
                 if (!reservationEntityForRead.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 조회할 수 있습니다.");
                 }
                 break;
-
             case "OWNER":
                 if (!reservationEntityForRead.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 조회할 수 있습니다.");
                 }
                 break;
-
             default:
                 throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
         }
 
         return ReservationGetByIdResDTOV1.of(reservationEntityForRead);
+    }
+
+    @Transactional(readOnly = true)
+    public ReservationSearchResDTOV1 searchByAdmin(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
+
+        validateUserRole(userRole,"ADMIN" );
+
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, userRole, id, userId, restaurantId, sort);
+
+        return ReservationSearchResDTOV1.of(reservationEntityPage);
+    }
+
+    @Transactional(readOnly = true)
+    public ReservationSearchResDTOV1 searchByCustomer(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
+
+        validateUserRole(userRole,"USER" );
+
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, userRole, id, userId, restaurantId, sort);
+
+        return ReservationSearchResDTOV1.of(reservationEntityPage);
+    }
+
+    @Transactional(readOnly = true)
+    public ReservationSearchResDTOV1 searchByOwner(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
+
+        validateUserRole(userRole,"OWNER" );
+
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, userRole, id, userId, restaurantId, sort);
+
+        return ReservationSearchResDTOV1.of(reservationEntityPage);
     }
 
     @Transactional
@@ -91,19 +122,16 @@ public class ReservationServiceV1 {
             case "ADMIN":
                 // 관리자는 모든 예약 상태 변경 가능
                 break;
-
             case "USER":
                 if (!reservationEntityForUpdate.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 취소할 수 있습니다.");
                 }
                 break;
-
             case "OWNER":
                 if (!reservationEntityForUpdate.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 취소할 수 있습니다.");
                 }
                 break;
-
             default:
                 throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
         }
@@ -124,21 +152,18 @@ public class ReservationServiceV1 {
         // 권한별 처리
         switch (userRole) {
             case "ADMIN":
-                // 관리자는 모든 예약 상태 변경 가능
+                // 관리자는 모든 예약 삭제 가능
                 break;
-
             case "USER":
                 if (!reservationEntityForDelete.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 삭제할 수 있습니다.");
                 }
                 break;
-
             case "OWNER":
                 if (!reservationEntityForDelete.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 삭제할 수 있습니다.");
                 }
                 break;
-
             default:
                 throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
         }
@@ -158,5 +183,12 @@ public class ReservationServiceV1 {
         return reservationRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
                 () -> new EntityNotFoundException("존재하지 않는 예약입니다.")
         );
+    }
+
+    // 권한 검증
+    private void validateUserRole(String userRole, String requiredRole) {
+        if (!userRole.equals(requiredRole)) {
+            throw new UnauthorizedAccessException("올바른 권한이 아닙니다.");
+        }
     }
 }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -1,16 +1,20 @@
 package com.qring.reservation.application.v1.service;
 
 import com.qring.reservation.application.global.exception.BadRequestException;
+import com.qring.reservation.application.global.exception.EntityNotFoundException;
 import com.qring.reservation.application.global.exception.UnauthorizedAccessException;
 import com.qring.reservation.application.v1.res.ReservationGetByIdResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
 import com.qring.reservation.domain.model.ReservationEntity;
+import com.qring.reservation.domain.model.constraint.ReservationStatus;
 import com.qring.reservation.domain.repository.ReservationRepository;
 import com.qring.reservation.presentation.v1.req.PostReservationReqDTOV1;
+import com.qring.reservation.presentation.v1.req.PutReservationReqDTOV1;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -70,6 +74,42 @@ public class ReservationServiceV1 {
         return ReservationGetByIdResDTOV1.of(reservationEntityForRead);
     }
 
+    @Transactional
+    public void putBy(String userRole, Long userId, @PathVariable Long id, PutReservationReqDTOV1 dto){
+
+        ReservationEntity reservationEntityForUpdate = getReservationEntityById(id);
+
+        Long restaurantId = 1L;
+
+        // 예약 상태 확인 (취소 상태인 경우 수정 불가)
+        if (reservationEntityForUpdate.getStatus() == ReservationStatus.CANCELLED) {
+            throw new BadRequestException("이미 취소된 예약입니다.");
+        }
+
+        // 권한별 처리
+        switch (userRole) {
+            case "ADMIN":
+                // 관리자는 모든 예약 상태 변경 가능
+                break;
+
+            case "USER":
+                if (!reservationEntityForUpdate.getUserId().equals(userId)) {
+                    throw new UnauthorizedAccessException("자신의 예약만 취소할 수 있습니다.");
+                }
+                break;
+
+            case "OWNER":
+                if (!reservationEntityForUpdate.getRestaurantId().equals(restaurantId)) {
+                    throw new UnauthorizedAccessException("자신의 식당 예약만 취소할 수 있습니다.");
+                }
+                break;
+
+            default:
+                throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
+        }
+
+        reservationEntityForUpdate.updateReservationEntityStatus(dto.getReservation().getStatus());
+    }
 
     private void publishReservationCreateEvent(Long reservationId) {
 
@@ -81,7 +121,7 @@ public class ReservationServiceV1 {
 
     private ReservationEntity getReservationEntityById(Long id) {
         return reservationRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
-                () -> new BadRequestException("존재하지 않는 예약입니다.")
+                () -> new EntityNotFoundException("존재하지 않는 예약입니다.")
         );
     }
 }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -39,7 +39,7 @@ public class ReservationServiceV1 {
 
         reservationRepository.save(reservationEntityForSave);
 
-        publishReservationCreateEvent(reservationEntityForSave.getId());
+        //publishReservationCreateEvent(reservationEntityForSave.getId());
 
         return ReservationPostResDTOV1.of(reservationEntityForSave);
     }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -9,6 +9,7 @@ import com.qring.reservation.application.v1.res.ReservationSearchResDTOV1;
 import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.domain.model.constraint.ReservationStatus;
 import com.qring.reservation.domain.repository.ReservationRepository;
+import com.qring.reservation.infrastructure.util.PassportUtil;
 import com.qring.reservation.presentation.v1.req.PostReservationReqDTOV1;
 import com.qring.reservation.presentation.v1.req.PutReservationReqDTOV1;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +18,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
 
-import java.nio.file.AccessDeniedException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -31,10 +29,10 @@ public class ReservationServiceV1 {
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Transactional
-    public ReservationPostResDTOV1 postBy(Long userId, PostReservationReqDTOV1 dto){
+    public ReservationPostResDTOV1 postBy(String passport, PostReservationReqDTOV1 dto){
 
         ReservationEntity reservationEntityForSave = ReservationEntity.createReservationEntity(
-                userId,
+                PassportUtil.getUserId(passport),
                 dto.getReservation().getRestaurantId(),
                 dto.getReservation().getHeadCount()
         );
@@ -47,66 +45,83 @@ public class ReservationServiceV1 {
     }
 
     @Transactional(readOnly = true)
-    public ReservationGetByIdResDTOV1 getBy(String userRole, Long userId, Long id) {
+    public ReservationGetByIdResDTOV1 getBy(String passport, Long id) {
+
+        String role = PassportUtil.getRole(passport);
+        Long userId = PassportUtil.getUserId(passport);
 
         ReservationEntity reservationEntityForRead = getReservationEntityById(id);
 
         Long restaurantId = 1L;
 
         // 권한별 처리
-        switch (userRole) {
-            case "ADMIN":
+        switch (role) {
+            case "관리자":
                 // 관리자는 모든 예약에 접근 가능
                 break;
-            case "USER":
+            case "고객":
                 if (!reservationEntityForRead.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 조회할 수 있습니다.");
                 }
                 break;
-            case "OWNER":
+            case "점주":
                 if (!reservationEntityForRead.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 조회할 수 있습니다.");
                 }
                 break;
             default:
-                throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
+                throw new BadRequestException("유효하지 않은 역할입니다: " + role);
         }
 
         return ReservationGetByIdResDTOV1.of(reservationEntityForRead);
     }
 
     @Transactional(readOnly = true)
-    public ReservationSearchResDTOV1 searchByAdmin(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
+    public ReservationSearchResDTOV1 searchByAdmin(Pageable pageable, String passport, Long userId, Long restaurantId, Long id, String sort) {
 
-        validateUserRole(userRole,"ADMIN" );
+        String role = PassportUtil.getRole(passport);
 
-        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, userRole, id, userId, restaurantId, sort);
+        validateRole(role,"관리자");
 
-        return ReservationSearchResDTOV1.of(reservationEntityPage);
-    }
-
-    @Transactional(readOnly = true)
-    public ReservationSearchResDTOV1 searchByCustomer(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
-
-        validateUserRole(userRole,"USER" );
-
-        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, userRole, id, userId, restaurantId, sort);
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
 
         return ReservationSearchResDTOV1.of(reservationEntityPage);
     }
 
     @Transactional(readOnly = true)
-    public ReservationSearchResDTOV1 searchByOwner(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
+    public ReservationSearchResDTOV1 searchByCustomer(Pageable pageable, String passport, Long restaurantId, Long id, String sort) {
 
-        validateUserRole(userRole,"OWNER" );
+        String role = PassportUtil.getRole(passport);
+        Long userId = PassportUtil.getUserId(passport);
 
-        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, userRole, id, userId, restaurantId, sort);
+        validateRole(role,"고객");
+
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
+
+        return ReservationSearchResDTOV1.of(reservationEntityPage);
+    }
+
+    @Transactional(readOnly = true)
+    public ReservationSearchResDTOV1 searchByOwner(Pageable pageable, String passport, Long userId, Long id, String sort) {
+
+        String role = PassportUtil.getRole(passport);
+        Long userIdOfOwner = PassportUtil.getUserId(passport);
+
+        // 점주의 소유 식당 목록 - 구현 예정
+        Long restaurantId = 1L;
+
+        validateRole(role,"점주");
+
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
 
         return ReservationSearchResDTOV1.of(reservationEntityPage);
     }
 
     @Transactional
-    public void putBy(String userRole, Long userId, @PathVariable Long id, PutReservationReqDTOV1 dto){
+    public void putBy(String passport, Long id, PutReservationReqDTOV1 dto){
+
+        String role = PassportUtil.getRole(passport);
+        Long userId = PassportUtil.getUserId(passport);
 
         ReservationEntity reservationEntityForUpdate = getReservationEntityById(id);
 
@@ -118,54 +133,57 @@ public class ReservationServiceV1 {
         }
 
         // 권한별 처리
-        switch (userRole) {
-            case "ADMIN":
+        switch (role) {
+            case "관리자":
                 // 관리자는 모든 예약 상태 변경 가능
                 break;
-            case "USER":
+            case "고객":
                 if (!reservationEntityForUpdate.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 취소할 수 있습니다.");
                 }
                 break;
-            case "OWNER":
+            case "점주":
                 if (!reservationEntityForUpdate.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 취소할 수 있습니다.");
                 }
                 break;
             default:
-                throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
+                throw new BadRequestException("유효하지 않은 역할입니다: " + role);
         }
 
         reservationEntityForUpdate.updateReservationEntityStatus(dto.getReservation().getStatus());
     }
 
     @Transactional
-    public void deleteBy(String userRole, Long userId, @PathVariable Long id){
+    public void deleteBy(String passport, Long id){
+
+        String role = PassportUtil.getRole(passport);
+        Long userId = PassportUtil.getUserId(passport);
+        String username = PassportUtil.getUsername(passport);
 
         ReservationEntity reservationEntityForDelete = getReservationEntityById(id);
 
-        String username = "test";
         Long restaurantId = 1L;
 
         // 대기 상태 확인 (대기중인 경우 삭제 불가) - 구현 예정
 
         // 권한별 처리
-        switch (userRole) {
-            case "ADMIN":
+        switch (role) {
+            case "관리자":
                 // 관리자는 모든 예약 삭제 가능
                 break;
-            case "USER":
+            case "고객":
                 if (!reservationEntityForDelete.getUserId().equals(userId)) {
                     throw new UnauthorizedAccessException("자신의 예약만 삭제할 수 있습니다.");
                 }
                 break;
-            case "OWNER":
+            case "점주":
                 if (!reservationEntityForDelete.getRestaurantId().equals(restaurantId)) {
                     throw new UnauthorizedAccessException("자신의 식당 예약만 삭제할 수 있습니다.");
                 }
                 break;
             default:
-                throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
+                throw new BadRequestException("유효하지 않은 역할입니다: " + role);
         }
 
         reservationEntityForDelete.deleteReservationEntity(username);
@@ -186,8 +204,8 @@ public class ReservationServiceV1 {
     }
 
     // 권한 검증
-    private void validateUserRole(String userRole, String requiredRole) {
-        if (!userRole.equals(requiredRole)) {
+    private void validateRole(String role, String requiredRole) {
+        if (!role.equals(requiredRole)) {
             throw new UnauthorizedAccessException("올바른 권한이 아닙니다.");
         }
     }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -39,7 +39,12 @@ public class ReservationServiceV1 {
 
         reservationRepository.save(reservationEntityForSave);
 
-        //publishReservationCreateEvent(reservationEntityForSave.getId());
+        ReservationPostResDTOV1.ReservationInfo reservationInfo = ReservationPostResDTOV1.ReservationInfo.from(
+                reservationEntityForSave.getId(),
+                reservationEntityForSave.getRestaurantId()
+        );
+
+        publishReservationCreateEvent(reservationInfo);
 
         return ReservationPostResDTOV1.of(reservationEntityForSave);
     }
@@ -189,12 +194,9 @@ public class ReservationServiceV1 {
         reservationEntityForDelete.deleteReservationEntity(username);
     }
 
-    private void publishReservationCreateEvent(Long reservationId) {
+    private void publishReservationCreateEvent(ReservationPostResDTOV1.ReservationInfo reservationInfo) {
 
-        Map<String, Object> event = new HashMap<>();
-        event.put("reservationId", reservationId);
-
-        kafkaTemplate.send("reservation-create-event-topic", event);
+        kafkaTemplate.send("reservation-create-event-topic", reservationInfo);
     }
 
     private ReservationEntity getReservationEntityById(Long id) {

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -1,5 +1,8 @@
 package com.qring.reservation.application.v1.service;
 
+import com.qring.reservation.application.global.exception.BadRequestException;
+import com.qring.reservation.application.global.exception.UnauthorizedAccessException;
+import com.qring.reservation.application.v1.res.ReservationGetByIdResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
 import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.domain.repository.ReservationRepository;
@@ -7,6 +10,7 @@ import com.qring.reservation.presentation.v1.req.PostReservationReqDTOV1;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +22,7 @@ public class ReservationServiceV1 {
     private final ReservationRepository reservationRepository;
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
+    @Transactional
     public ReservationPostResDTOV1 postBy(Long userId, PostReservationReqDTOV1 dto){
 
         ReservationEntity reservationEntityForSave = ReservationEntity.createReservationEntity(
@@ -33,11 +38,50 @@ public class ReservationServiceV1 {
         return ReservationPostResDTOV1.of(reservationEntityForSave);
     }
 
+    @Transactional(readOnly = true)
+    public ReservationGetByIdResDTOV1 getBy(String userRole, Long userId, Long id) {
+
+        ReservationEntity reservationEntityForRead = getReservationEntityById(id);
+
+        Long restaurantId = 1L;
+
+        // 권한별 처리
+        switch (userRole) {
+            case "ADMIN":
+                // 관리자는 모든 예약에 접근 가능
+                break;
+
+            case "USER":
+                if (!reservationEntityForRead.getUserId().equals(userId)) {
+                    throw new UnauthorizedAccessException("자신의 예약만 조회할 수 있습니다.");
+                }
+                break;
+
+            case "OWNER":
+                if (!reservationEntityForRead.getRestaurantId().equals(restaurantId)) {
+                    throw new UnauthorizedAccessException("자신의 식당 예약만 조회할 수 있습니다.");
+                }
+                break;
+
+            default:
+                throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
+        }
+
+        return ReservationGetByIdResDTOV1.of(reservationEntityForRead);
+    }
+
+
     private void publishReservationCreateEvent(Long reservationId) {
 
         Map<String, Object> event = new HashMap<>();
         event.put("reservationId", reservationId);
 
         kafkaTemplate.send("reservation-create-event-topic", event);
+    }
+
+    private ReservationEntity getReservationEntityById(Long id) {
+        return reservationRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
+                () -> new BadRequestException("존재하지 않는 예약입니다.")
+        );
     }
 }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -3,6 +3,7 @@ package com.qring.reservation.application.v1.service;
 import com.qring.reservation.application.global.exception.BadRequestException;
 import com.qring.reservation.application.global.exception.EntityNotFoundException;
 import com.qring.reservation.application.global.exception.UnauthorizedAccessException;
+import com.qring.reservation.application.v1.message.KafkaMessageProducerV1;
 import com.qring.reservation.application.v1.res.ReservationGetByIdResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationSearchResDTOV1;
@@ -15,7 +16,6 @@ import com.qring.reservation.presentation.v1.req.PutReservationReqDTOV1;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +26,7 @@ import java.util.*;
 public class ReservationServiceV1 {
 
     private final ReservationRepository reservationRepository;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaMessageProducerV1 kafkaMessageProducerV1;
 
     @Transactional
     public ReservationPostResDTOV1 postBy(String passport, PostReservationReqDTOV1 dto) {
@@ -44,7 +44,7 @@ public class ReservationServiceV1 {
                 reservationEntityForSave.getRestaurantId()
         );
 
-        publishReservationCreateEvent(reservationInfo);
+        kafkaMessageProducerV1.publishReservationCreateEvent(reservationInfo);
 
         return ReservationPostResDTOV1.of(reservationEntityForSave);
     }
@@ -192,11 +192,6 @@ public class ReservationServiceV1 {
         }
 
         reservationEntityForDelete.deleteReservationEntity(username);
-    }
-
-    private void publishReservationCreateEvent(ReservationPostResDTOV1.ReservationInfo reservationInfo) {
-
-        kafkaTemplate.send("reservation-create-event-topic", reservationInfo);
     }
 
     private ReservationEntity getReservationEntityById(Long id) {

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -111,6 +111,41 @@ public class ReservationServiceV1 {
         reservationEntityForUpdate.updateReservationEntityStatus(dto.getReservation().getStatus());
     }
 
+    @Transactional
+    public void deleteBy(String userRole, Long userId, @PathVariable Long id){
+
+        ReservationEntity reservationEntityForDelete = getReservationEntityById(id);
+
+        String username = "test";
+        Long restaurantId = 1L;
+
+        // 대기 상태 확인 (대기중인 경우 삭제 불가) - 구현 예정
+
+        // 권한별 처리
+        switch (userRole) {
+            case "ADMIN":
+                // 관리자는 모든 예약 상태 변경 가능
+                break;
+
+            case "USER":
+                if (!reservationEntityForDelete.getUserId().equals(userId)) {
+                    throw new UnauthorizedAccessException("자신의 예약만 삭제할 수 있습니다.");
+                }
+                break;
+
+            case "OWNER":
+                if (!reservationEntityForDelete.getRestaurantId().equals(restaurantId)) {
+                    throw new UnauthorizedAccessException("자신의 식당 예약만 삭제할 수 있습니다.");
+                }
+                break;
+
+            default:
+                throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
+        }
+
+        reservationEntityForDelete.deleteReservationEntity(username);
+    }
+
     private void publishReservationCreateEvent(Long reservationId) {
 
         Map<String, Object> event = new HashMap<>();

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -52,31 +52,9 @@ public class ReservationServiceV1 {
     @Transactional(readOnly = true)
     public ReservationGetByIdResDTOV1 getBy(String passport, Long id) {
 
-        String role = PassportUtil.getRole(passport);
-        Long userId = PassportUtil.getUserId(passport);
-
         ReservationEntity reservationEntityForMapping = getReservationEntityById(id);
 
-        Long restaurantId = 1L;
-
-        // 권한별 처리
-        switch (role) {
-            case "관리자":
-                // 관리자는 모든 예약에 접근 가능
-                break;
-            case "고객":
-                if (!reservationEntityForMapping.getUserId().equals(userId)) {
-                    throw new UnauthorizedAccessException("자신의 예약만 조회할 수 있습니다.");
-                }
-                break;
-            case "점주":
-                if (!reservationEntityForMapping.getRestaurantId().equals(restaurantId)) {
-                    throw new UnauthorizedAccessException("자신의 식당 예약만 조회할 수 있습니다.");
-                }
-                break;
-            default:
-                throw new BadRequestException("유효하지 않은 역할입니다: " + role);
-        }
+        validateAccess(passport, reservationEntityForMapping.getUserId(), reservationEntityForMapping.getRestaurantId());
 
         return ReservationGetByIdResDTOV1.of(reservationEntityForMapping);
     }
@@ -84,11 +62,15 @@ public class ReservationServiceV1 {
     @Transactional(readOnly = true)
     public ReservationSearchResDTOV1 searchByAdmin(Pageable pageable, String passport, Long userId, Long restaurantId, Long id, String sort) {
 
-        String role = PassportUtil.getRole(passport);
+        validateUserRole(PassportUtil.getRole(passport), "관리자");
 
-        validateUserRole(role, "관리자");
-
-        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(
+                pageable,
+                "관리자",
+                userId,
+                restaurantId,
+                id,
+                sort);
 
         return ReservationSearchResDTOV1.of(reservationEntityPage);
     }
@@ -96,12 +78,16 @@ public class ReservationServiceV1 {
     @Transactional(readOnly = true)
     public ReservationSearchResDTOV1 searchByCustomer(Pageable pageable, String passport, Long restaurantId, Long id, String sort) {
 
-        String role = PassportUtil.getRole(passport);
-        Long userId = PassportUtil.getUserId(passport);
+        validateUserRole(PassportUtil.getRole(passport), "고객");
 
-        validateUserRole(role, "고객");
-
-        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(
+                pageable,
+                "고객",
+                PassportUtil.getUserId(passport),
+                restaurantId,
+                id,
+                sort
+        );
 
         return ReservationSearchResDTOV1.of(reservationEntityPage);
     }
@@ -109,15 +95,20 @@ public class ReservationServiceV1 {
     @Transactional(readOnly = true)
     public ReservationSearchResDTOV1 searchByOwner(Pageable pageable, String passport, Long userId, Long restaurantId, Long id, String sort) {
 
-        String role = PassportUtil.getRole(passport);
-        Long userIdOfOwner = PassportUtil.getUserId(passport);
+        validateUserRole(PassportUtil.getRole(passport), "점주");
 
         // 점주의 소유 식당 목록 - 구현 예정
+        Long userIdOfOwner = PassportUtil.getUserId(passport);
         List<Long> restaurantIdListOfOwner = Arrays.asList(1L, 6L);
 
-        validateUserRole(role, "점주");
-
-        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithOwnerConditions(pageable, restaurantIdListOfOwner, userId, restaurantId, id, sort);
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithOwnerConditions(
+                pageable,
+                restaurantIdListOfOwner,
+                userId,
+                restaurantId,
+                id,
+                sort
+        );
 
         return ReservationSearchResDTOV1.of(reservationEntityPage);
     }
@@ -125,36 +116,13 @@ public class ReservationServiceV1 {
     @Transactional
     public void putBy(String passport, Long id, PutReservationReqDTOV1 dto) {
 
-        String role = PassportUtil.getRole(passport);
-        Long userId = PassportUtil.getUserId(passport);
-
         ReservationEntity reservationEntityForModify = getReservationEntityById(id);
 
-        Long restaurantId = 1L;
-
-        // 예약 상태 확인 (취소 상태인 경우 수정 불가)
         if (reservationEntityForModify.getStatus() == ReservationStatus.CANCELLED) {
             throw new BadRequestException("이미 취소된 예약입니다.");
         }
 
-        // 권한별 처리
-        switch (role) {
-            case "관리자":
-                // 관리자는 모든 예약 상태 변경 가능
-                break;
-            case "고객":
-                if (!reservationEntityForModify.getUserId().equals(userId)) {
-                    throw new UnauthorizedAccessException("자신의 예약만 취소할 수 있습니다.");
-                }
-                break;
-            case "점주":
-                if (!reservationEntityForModify.getRestaurantId().equals(restaurantId)) {
-                    throw new UnauthorizedAccessException("자신의 식당 예약만 취소할 수 있습니다.");
-                }
-                break;
-            default:
-                throw new BadRequestException("유효하지 않은 역할입니다: " + role);
-        }
+        validateAccess(passport, reservationEntityForModify.getUserId(), reservationEntityForModify.getRestaurantId());
 
         reservationEntityForModify.updateReservationEntityStatus(dto.getReservation().getStatus());
     }
@@ -162,48 +130,47 @@ public class ReservationServiceV1 {
     @Transactional
     public void deleteBy(String passport, Long id) {
 
-        String role = PassportUtil.getRole(passport);
-        Long userId = PassportUtil.getUserId(passport);
-        String username = PassportUtil.getUsername(passport);
-
         ReservationEntity reservationEntityForDelete = getReservationEntityById(id);
-
-        Long restaurantId = 1L;
 
         // 대기 상태 확인 (대기중인 경우 삭제 불가) - 구현 예정
 
-        // 권한별 처리
+        validateAccess(passport, reservationEntityForDelete.getUserId(), reservationEntityForDelete.getRestaurantId());
+
+        reservationEntityForDelete.deleteReservationEntity(PassportUtil.getUsername(passport));
+    }
+
+    private void validateAccess(String passport, Long userId, Long restaurantId) {
+
+        String role = PassportUtil.getRole(passport);
+        Long userIdOfPassport = PassportUtil.getUserId(passport);
+        List<Long> restaurantIdListOfOwner = Arrays.asList(1L, 6L); // 점주의 소유 식당 목록
+
         switch (role) {
             case "관리자":
-                // 관리자는 모든 예약 삭제 가능
                 break;
             case "고객":
-                if (!reservationEntityForDelete.getUserId().equals(userId)) {
-                    throw new UnauthorizedAccessException("자신의 예약만 삭제할 수 있습니다.");
+                if (!Objects.equals(userIdOfPassport, userId)) {
+                    throw new UnauthorizedAccessException("자신의 예약만 접근할 수 있습니다.");
                 }
                 break;
             case "점주":
-                if (!reservationEntityForDelete.getRestaurantId().equals(restaurantId)) {
-                    throw new UnauthorizedAccessException("자신의 식당 예약만 삭제할 수 있습니다.");
+                if (!restaurantIdListOfOwner.contains(restaurantId)) {
+                    throw new UnauthorizedAccessException("자신의 식당 예약만 접근할 수 있습니다.");
                 }
                 break;
             default:
                 throw new BadRequestException("유효하지 않은 역할입니다: " + role);
         }
-
-        reservationEntityForDelete.deleteReservationEntity(username);
     }
 
     private ReservationEntity getReservationEntityById(Long id) {
-        return reservationRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
-                () -> new EntityNotFoundException("존재하지 않는 예약입니다.")
-        );
+        return reservationRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 예약입니다."));
     }
 
-    // 권한 검증
     private void validateUserRole(String role, String requiredRole) {
         if (!role.equals(requiredRole)) {
-            throw new UnauthorizedAccessException("접근 권한이 없습니다");
+            throw new UnauthorizedAccessException("접근 권한이 없습니다.");
         }
     }
 }

--- a/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
+++ b/src/main/java/com/qring/reservation/application/v1/service/ReservationServiceV1.java
@@ -102,17 +102,17 @@ public class ReservationServiceV1 {
     }
 
     @Transactional(readOnly = true)
-    public ReservationSearchResDTOV1 searchByOwner(Pageable pageable, String passport, Long userId, Long id, String sort) {
+    public ReservationSearchResDTOV1 searchByOwner(Pageable pageable, String passport, Long userId, Long restaurantId, Long id, String sort) {
 
         String role = PassportUtil.getRole(passport);
         Long userIdOfOwner = PassportUtil.getUserId(passport);
 
         // 점주의 소유 식당 목록 - 구현 예정
-        Long restaurantId = 1L;
+        List<Long> restaurantIdListOfOwner = Arrays.asList(1L, 6L);
 
         validateRole(role,"점주");
 
-        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithConditions(pageable, role, userId, restaurantId, id, sort);
+        Page<ReservationEntity> reservationEntityPage = reservationRepository.findReservationPageByDeletedAtIsNullWithOwnerConditions(pageable, restaurantIdListOfOwner, userId, restaurantId, id, sort);
 
         return ReservationSearchResDTOV1.of(reservationEntityPage);
     }

--- a/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
+++ b/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
@@ -26,7 +26,7 @@ public class ReservationEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "restaurant_Id", nullable = false)
+    @Column(name = "restaurant_id", nullable = false)
     private Long restaurantId;
 
     @Column(name = "status", nullable = false)
@@ -47,7 +47,7 @@ public class ReservationEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Column(name = "created_by", updatable = false)
+    @Column(name = "created_by", nullable = false, updatable = false)
     private String createdBy;
 
     @Column(name = "modified_by", nullable = false)
@@ -57,18 +57,10 @@ public class ReservationEntity {
     private String deletedBy;
 
     @Builder
-    public ReservationEntity(Long userId, Long restaurantId, int headCount) {
+    public ReservationEntity(Long userId, Long restaurantId, ReservationStatus status, int headCount) {
         this.userId = userId;
         this.restaurantId = restaurantId;
-        this.status = ReservationStatus.CONFIRMED;
+        this.status = status;
         this.headCount = headCount;
-    }
-
-    public static ReservationEntity createReservationEntity(Long userId, Long restaurantId, int headCount) {
-        return ReservationEntity.builder()
-                .userId(userId)
-                .restaurantId(restaurantId)
-                .headCount(headCount)
-                .build();
     }
 }

--- a/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
+++ b/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
@@ -63,4 +63,13 @@ public class ReservationEntity {
         this.status = status;
         this.headCount = headCount;
     }
+
+    public static ReservationEntity createReservationEntity(Long userId, Long restaurantId, int headCount) {
+        return ReservationEntity.builder()
+                .userId(userId)
+                .restaurantId(restaurantId)
+                .status(ReservationStatus.CONFIRMED)
+                .headCount(headCount)
+                .build();
+    }
 }

--- a/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
+++ b/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
@@ -63,4 +63,12 @@ public class ReservationEntity {
         this.status = ReservationStatus.CONFIRMED;
         this.headCount = headCount;
     }
+
+    public static ReservationEntity createReservationEntity(Long userId, Long restaurantId, int headCount) {
+        return ReservationEntity.builder()
+                .userId(userId)
+                .restaurantId(restaurantId)
+                .headCount(headCount)
+                .build();
+    }
 }

--- a/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
+++ b/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
@@ -73,7 +73,7 @@ public class ReservationEntity {
                 .build();
     }
 
-    public void changeReservationStatus(String reservationStatus) {
+    public void updateReservationEntityStatus(String reservationStatus) {
         this.status = ReservationStatus.fromString(reservationStatus);
     }
 }

--- a/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
+++ b/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
@@ -76,4 +76,9 @@ public class ReservationEntity {
     public void updateReservationEntityStatus(String reservationStatus) {
         this.status = ReservationStatus.fromString(reservationStatus);
     }
+
+    public void deleteReservationEntity(String username) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = username;
+    }
 }

--- a/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
+++ b/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
@@ -72,4 +72,8 @@ public class ReservationEntity {
                 .headCount(headCount)
                 .build();
     }
+
+    public void changeReservationStatus(String reservationStatus) {
+        this.status = ReservationStatus.fromString(reservationStatus);
+    }
 }

--- a/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
+++ b/src/main/java/com/qring/reservation/domain/model/ReservationEntity.java
@@ -10,12 +10,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "p_reservation")
 public class ReservationEntity {
 
@@ -47,9 +51,11 @@ public class ReservationEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @CreatedBy
     @Column(name = "created_by", nullable = false, updatable = false)
     private String createdBy;
 
+    @LastModifiedBy
     @Column(name = "modified_by", nullable = false)
     private String modifiedBy;
 

--- a/src/main/java/com/qring/reservation/domain/model/constraint/ReservationStatus.java
+++ b/src/main/java/com/qring/reservation/domain/model/constraint/ReservationStatus.java
@@ -6,13 +6,21 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ReservationStatus {
-    CONFIRMED(Status.CONFIRMED), // 확정
-    CANCELLED(Status.CANCELLED); // 취소
+    CONFIRMED(Status.CONFIRMED),
+    CANCELLED(Status.CANCELLED);
 
     private final String status;
 
     public static class Status {
-        public static final String CONFIRMED = "STATUS_CONFIRMED";
-        public static final String CANCELLED = "STATUS_CANCELLED";
+        public static final String CONFIRMED = "확정";
+        public static final String CANCELLED = "취소";
+    }
+
+    public static ReservationStatus fromString(String status) {
+        return switch (status) {
+            case Status.CONFIRMED -> ReservationStatus.CONFIRMED;
+            case Status.CANCELLED -> ReservationStatus.CANCELLED;
+            default -> throw new IllegalArgumentException("유효하지 않은 상태입니다.");
+        };
     }
 }

--- a/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
@@ -1,0 +1,4 @@
+package com.qring.reservation.domain.repository;
+
+public interface ReservationRepository {
+}

--- a/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
@@ -1,4 +1,9 @@
 package com.qring.reservation.domain.repository;
 
+import com.qring.reservation.domain.model.ReservationEntity;
+
 public interface ReservationRepository {
+
+    ReservationEntity save(ReservationEntity reservationEntity);
+
 }

--- a/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
@@ -12,6 +12,6 @@ public interface ReservationRepository {
 
     Optional<ReservationEntity> findByIdAndDeletedAtIsNull(Long id);
 
-    Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithConditions(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort);
+    Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithConditions(Pageable pageable, String userRole, Long userId, Long restaurantId, Long id, String sort);
 
 }

--- a/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
@@ -2,8 +2,12 @@ package com.qring.reservation.domain.repository;
 
 import com.qring.reservation.domain.model.ReservationEntity;
 
+import java.util.Optional;
+
 public interface ReservationRepository {
 
     ReservationEntity save(ReservationEntity reservationEntity);
+
+    Optional<ReservationEntity> findByIdAndDeletedAtIsNull(Long id);
 
 }

--- a/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
@@ -1,6 +1,8 @@
 package com.qring.reservation.domain.repository;
 
 import com.qring.reservation.domain.model.ReservationEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -9,5 +11,7 @@ public interface ReservationRepository {
     ReservationEntity save(ReservationEntity reservationEntity);
 
     Optional<ReservationEntity> findByIdAndDeletedAtIsNull(Long id);
+
+    Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithConditions(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort);
 
 }

--- a/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/qring/reservation/domain/repository/ReservationRepository.java
@@ -4,6 +4,7 @@ import com.qring.reservation.domain.model.ReservationEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReservationRepository {
@@ -13,5 +14,7 @@ public interface ReservationRepository {
     Optional<ReservationEntity> findByIdAndDeletedAtIsNull(Long id);
 
     Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithConditions(Pageable pageable, String userRole, Long userId, Long restaurantId, Long id, String sort);
+
+    Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithOwnerConditions(Pageable pageable, List<Long> restaurantIdListOfOwner, Long userId, Long restaurantId, Long id, String sort);
 
 }

--- a/src/main/java/com/qring/reservation/infrastructure/auditing/AuditorAwareImpl.java
+++ b/src/main/java/com/qring/reservation/infrastructure/auditing/AuditorAwareImpl.java
@@ -1,0 +1,28 @@
+package com.qring.reservation.infrastructure.auditing;
+
+import com.qring.reservation.infrastructure.util.PassportUtil;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Optional;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        String passport = attributes.getRequest().getHeader("X-Passport-Token");
+
+        if (passport != null) {
+            String username = PassportUtil.getUsername(passport);
+            return Optional.ofNullable(username);
+        }
+
+        return Optional.of("Guest");
+    }
+}

--- a/src/main/java/com/qring/reservation/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/qring/reservation/infrastructure/config/JpaConfig.java
@@ -1,0 +1,8 @@
+package com.qring.reservation.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+}

--- a/src/main/java/com/qring/reservation/infrastructure/config/QuerydslConfig.java
+++ b/src/main/java/com/qring/reservation/infrastructure/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.qring.reservation.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/qring/reservation/infrastructure/config/ReservationKafkaConfig.java
+++ b/src/main/java/com/qring/reservation/infrastructure/config/ReservationKafkaConfig.java
@@ -1,0 +1,35 @@
+package com.qring.reservation.infrastructure.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReservationKafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public NewTopic reservationCreateEventTopic() {
+        return new NewTopic("reservation-create-event-topic", 1, (short) 1);
+    }
+}

--- a/src/main/java/com/qring/reservation/infrastructure/docs/ReservationControllerSwagger.java
+++ b/src/main/java/com/qring/reservation/infrastructure/docs/ReservationControllerSwagger.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Reservation", description = "생성, 조회, 검색, 수정, 삭제 관련 예약 API")
+@RequestMapping("/v1/reservations")
 public interface ReservationControllerSwagger {
 
     @Operation(summary = "예약 생성", description = "사용자의 ID 와 식당의 ID 를 기준으로 예약을 생성하는 API 입니다.")
@@ -36,8 +37,8 @@ public interface ReservationControllerSwagger {
             @ApiResponse(responseCode = "200", description = "예약 조회 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
             @ApiResponse(responseCode = "400", description = "예약 조회 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
-    @GetMapping("/{reservationId}")
-    ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@PathVariable Long reservationId);
+    @GetMapping("/{id}")
+    ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@PathVariable Long id);
 
 
     @Operation(summary = "예약 검색", description = "동적 조건을 기준으로 예약을 검색하는 API 입니다.")
@@ -48,7 +49,7 @@ public interface ReservationControllerSwagger {
     @GetMapping
     ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchBy(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
                                                                @RequestParam(name = "userId", required = false) Long userId,
-                                                               @RequestParam(name = "reservationId", required = false) Long reservationId,
+                                                               @RequestParam(name = "id", required = false) Long id,
                                                                @RequestParam(name = "restaurantId", required = false) Long restaurantId,
                                                                @RequestParam(name = "sort", required = false) String sort);
 
@@ -58,8 +59,8 @@ public interface ReservationControllerSwagger {
             @ApiResponse(responseCode = "200", description = "예약 수정 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
             @ApiResponse(responseCode = "400", description = "예약 수정 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
-    @PutMapping("/{reservationId}")
-    ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-User-Id") Long userId, @PathVariable Long reservationId, @RequestBody PutReservationReqDTOV1 dto);
+    @PutMapping("/{id}")
+    ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-User-Id") Long userId, @PathVariable Long id, @RequestBody PutReservationReqDTOV1 dto);
 
 
     @Operation(summary = "예약 삭제", description = "사용자의 ID 와 예약 ID 를 기준으로 예약을 삭제하는 API 입니다.")
@@ -67,6 +68,6 @@ public interface ReservationControllerSwagger {
             @ApiResponse(responseCode = "200", description = "예약 삭제 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
             @ApiResponse(responseCode = "400", description = "예약 삭제 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
-    @DeleteMapping("/{reservationId}")
-    ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-User-Id") Long userId, @PathVariable Long reservationId);
+    @DeleteMapping("/{id}")
+    ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-User-Id") Long userId, @PathVariable Long id);
 }

--- a/src/main/java/com/qring/reservation/infrastructure/docs/ReservationControllerSwagger.java
+++ b/src/main/java/com/qring/reservation/infrastructure/docs/ReservationControllerSwagger.java
@@ -29,7 +29,7 @@ public interface ReservationControllerSwagger {
             @ApiResponse(responseCode = "400", description = "예약 생성 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
     @PostMapping
-    ResponseEntity<ResDTO<ReservationPostResDTOV1>> postBy(@RequestHeader("X-User-Id") Long userId, @Valid@RequestBody PostReservationReqDTOV1 dto);
+    ResponseEntity<ResDTO<ReservationPostResDTOV1>> postBy(@RequestHeader("X-Passport-Token") String passport, @Valid@RequestBody PostReservationReqDTOV1 dto);
 
 
     @Operation(summary = "예약 상세 조회", description = "예약 ID 를 기준으로 예약을 상세 조회하는 API 입니다.")
@@ -38,20 +38,46 @@ public interface ReservationControllerSwagger {
             @ApiResponse(responseCode = "400", description = "예약 조회 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
     @GetMapping("/{id}")
-    ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@PathVariable Long id);
+    ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@RequestHeader("X-Passport-Token") String passport, @PathVariable Long id);
 
 
-    @Operation(summary = "예약 검색", description = "동적 조건을 기준으로 예약을 검색하는 API 입니다.")
+    @Operation(summary = "관리자 예약 검색", description = "동적 조건을 기준으로 관리자가 예약을 검색하는 API 입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "예약 검색 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
             @ApiResponse(responseCode = "400", description = "예약 검색 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
-    @GetMapping
-    ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchBy(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-                                                               @RequestParam(name = "userId", required = false) Long userId,
-                                                               @RequestParam(name = "id", required = false) Long id,
-                                                               @RequestParam(name = "restaurantId", required = false) Long restaurantId,
-                                                               @RequestParam(name = "sort", required = false) String sort);
+    @GetMapping("/admin")
+    ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByAdmin(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                    @RequestHeader("X-Passport-Token") String passport,
+                                                                    @RequestParam(name = "userId", required = false) Long userId,
+                                                                    @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                    @RequestParam(name = "id", required = false) Long id,
+                                                                    @RequestParam(name = "sort", required = false) String sort);
+
+    @Operation(summary = "고객 예약 검색", description = "동적 조건을 기준으로 고객이 예약을 검색하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "예약 검색 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "예약 검색 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
+    })
+    @GetMapping("/customer")
+    ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByCustomer(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                       @RequestHeader("X-Passport-Token") String passport,
+                                                                       @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                       @RequestParam(name = "id", required = false) Long id,
+                                                                       @RequestParam(name = "sort", required = false) String sort);
+
+    @Operation(summary = "점주 예약 검색", description = "동적 조건을 기준으로 점주가 예약을 검색하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "예약 검색 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "예약 검색 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
+    })
+    @GetMapping("/owner")
+    ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByOwner(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                    @RequestHeader("X-Passport-Token") String passport,
+                                                                    @RequestParam(name = "userId", required = false) Long userId,
+                                                                    @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                    @RequestParam(name = "id", required = false) Long id,
+                                                                    @RequestParam(name = "sort", required = false) String sort);
 
 
     @Operation(summary = "예약 상태 수정", description = "사용자의 ID 와 예약 ID 를 기준으로 예약 상태를 수정하는 API 입니다.")
@@ -60,7 +86,7 @@ public interface ReservationControllerSwagger {
             @ApiResponse(responseCode = "400", description = "예약 수정 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
     @PutMapping("/{id}")
-    ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-User-Id") Long userId, @PathVariable Long id, @RequestBody PutReservationReqDTOV1 dto);
+    ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-Passport-Token") String passport, @PathVariable Long id, @RequestBody PutReservationReqDTOV1 dto);
 
 
     @Operation(summary = "예약 삭제", description = "사용자의 ID 와 예약 ID 를 기준으로 예약을 삭제하는 API 입니다.")
@@ -69,5 +95,5 @@ public interface ReservationControllerSwagger {
             @ApiResponse(responseCode = "400", description = "예약 삭제 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
     @DeleteMapping("/{id}")
-    ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-User-Id") Long userId, @PathVariable Long id);
+    ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-Passport-Token") String passport, @PathVariable Long id);
 }

--- a/src/main/java/com/qring/reservation/infrastructure/messaging/KafkaMessageProducerImplV1.java
+++ b/src/main/java/com/qring/reservation/infrastructure/messaging/KafkaMessageProducerImplV1.java
@@ -1,0 +1,19 @@
+package com.qring.reservation.infrastructure.messaging;
+
+import com.qring.reservation.application.v1.message.KafkaMessageProducerV1;
+import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageProducerImplV1 implements KafkaMessageProducerV1 {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void publishReservationCreateEvent(ReservationPostResDTOV1.ReservationInfo reservationInfo) {
+
+        kafkaTemplate.send("reservation-create-event-topic", reservationInfo);
+    }
+}

--- a/src/main/java/com/qring/reservation/infrastructure/repository/JpaReservationRepository.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/JpaReservationRepository.java
@@ -1,0 +1,8 @@
+package com.qring.reservation.infrastructure.repository;
+
+import com.qring.reservation.domain.model.ReservationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaReservationRepository extends JpaRepository<ReservationEntity, Long> {
+
+}

--- a/src/main/java/com/qring/reservation/infrastructure/repository/JpaReservationRepository.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/JpaReservationRepository.java
@@ -3,6 +3,10 @@ package com.qring.reservation.infrastructure.repository;
 import com.qring.reservation.domain.model.ReservationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JpaReservationRepository extends JpaRepository<ReservationEntity, Long> {
+
+    Optional<ReservationEntity> findByIdAndDeletedAtIsNull(Long id);
 
 }

--- a/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.qring.reservation.infrastructure.repository;
+
+import com.qring.reservation.domain.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReservationRepositoryImpl implements ReservationRepository {
+
+}

--- a/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.qring.reservation.infrastructure.repository;
 
+import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.domain.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,9 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ReservationRepositoryImpl implements ReservationRepository {
 
+    private final JpaReservationRepository jpaReservationRepository;
+
+    public ReservationEntity save(ReservationEntity reservationEntity) {
+        return jpaReservationRepository.save(reservationEntity);
+    }
 }

--- a/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.qring.reservation.domain.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class ReservationRepositoryImpl implements ReservationRepository {
@@ -13,5 +15,9 @@ public class ReservationRepositoryImpl implements ReservationRepository {
 
     public ReservationEntity save(ReservationEntity reservationEntity) {
         return jpaReservationRepository.save(reservationEntity);
+    }
+
+    public Optional<ReservationEntity> findByIdAndDeletedAtIsNull(Long id) {
+        return jpaReservationRepository.findById(id);
     }
 }

--- a/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
@@ -1,8 +1,16 @@
 package com.qring.reservation.infrastructure.repository;
 
+import com.qring.reservation.application.global.exception.BadRequestException;
+import com.qring.reservation.domain.model.QReservationEntity;
 import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.domain.repository.ReservationRepository;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,12 +20,83 @@ import java.util.Optional;
 public class ReservationRepositoryImpl implements ReservationRepository {
 
     private final JpaReservationRepository jpaReservationRepository;
+    private final JPAQueryFactory jpaQueryFactory;
 
     public ReservationEntity save(ReservationEntity reservationEntity) {
         return jpaReservationRepository.save(reservationEntity);
     }
 
     public Optional<ReservationEntity> findByIdAndDeletedAtIsNull(Long id) {
-        return jpaReservationRepository.findById(id);
+        return jpaReservationRepository.findByIdAndDeletedAtIsNull(id);
+    }
+
+    // QueryDSL 동적 쿼리
+    public Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithConditions(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
+
+        QReservationEntity reservationEntity = QReservationEntity.reservationEntity;
+
+        // 권한 기반 조건 생성
+        BooleanExpression roleCondition = getRoleCondition(userRole, userId, restaurantId);
+
+        // Query 실행
+        var results = jpaQueryFactory
+                .selectFrom(reservationEntity)
+                .where(
+                        idEq(id, reservationEntity),
+                        userIdEq(userId, reservationEntity),
+                        restaurantIdEq(restaurantId, reservationEntity),
+                        reservationEntity.deletedAt.isNull(),
+                        roleCondition
+                )
+                .orderBy(getOrderSpecifier(sort, reservationEntity))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+
+        return new PageImpl<>(results.getResults(), pageable, results.getTotal());
+    }
+
+    // 권한별 조건 메서드
+    private BooleanExpression getRoleCondition(String userRole, Long userId, Long restaurantId) {
+        QReservationEntity reservation = QReservationEntity.reservationEntity;
+
+        switch (userRole) {
+            case "ADMIN":
+                return null; // 관리자는 모든 데이터를 조회 가능
+            case "USER":
+                return reservation.userId.eq(userId); // 고객은 자신의 예약만 조회 가능
+            case "OWNER":
+                return reservation.restaurantId.eq(restaurantId); // 주인은 자신의 식당 예약만 조회 가능
+            default:
+                throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
+        }
+    }
+
+    // 동적 쿼리 조건 메서드
+    private BooleanExpression idEq(Long id, QReservationEntity reservationEntity) {
+        return id != null ? reservationEntity.id.eq(id) : null;
+    }
+
+    private BooleanExpression userIdEq(Long userId, QReservationEntity reservationEntity) {
+        return userId != null ? reservationEntity.userId.eq(userId) : null;
+    }
+
+    private BooleanExpression restaurantIdEq(Long restaurantId, QReservationEntity reservationEntity) {
+        return restaurantId != null ? reservationEntity.restaurantId.eq(restaurantId) : null;
+    }
+
+    // 정렬 로직
+    private OrderSpecifier<?> getOrderSpecifier(String sort, QReservationEntity reservationEntity) {
+
+        switch (sort) {
+            case "SMALLEST":
+                return reservationEntity.headCount.asc(); // 인원수 오름차순
+            case "LARGEST":
+                return reservationEntity.headCount.desc(); // 인원수 내림차순
+            case "OLDEST":
+                return reservationEntity.createdAt.asc(); // 생성일 오름차순
+            default:
+                return reservationEntity.createdAt.desc();
+        }
     }
 }

--- a/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     // QueryDSL 동적 쿼리
-    public Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithConditions(Pageable pageable, String userRole, Long id, Long userId, Long restaurantId, String sort) {
+    public Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithConditions(Pageable pageable, String userRole, Long userId, Long restaurantId, Long id, String sort) {
 
         QReservationEntity reservationEntity = QReservationEntity.reservationEntity;
 
@@ -61,11 +61,11 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         QReservationEntity reservation = QReservationEntity.reservationEntity;
 
         switch (userRole) {
-            case "ADMIN":
+            case "관리자":
                 return null; // 관리자는 모든 데이터를 조회 가능
-            case "USER":
+            case "고객":
                 return reservation.userId.eq(userId); // 고객은 자신의 예약만 조회 가능
-            case "OWNER":
+            case "점주":
                 return reservation.restaurantId.eq(restaurantId); // 주인은 자신의 식당 예약만 조회 가능
             default:
                 throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);

--- a/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/qring/reservation/infrastructure/repository/ReservationRepositoryImpl.java
@@ -6,13 +6,15 @@ import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.domain.repository.ReservationRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -36,28 +38,72 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         QReservationEntity reservationEntity = QReservationEntity.reservationEntity;
 
         // 권한 기반 조건 생성
-        BooleanExpression roleCondition = getRoleCondition(userRole, userId, restaurantId);
+        BooleanExpression roleCondition = getRoleCondition(userRole, userId);
 
         // Query 실행
-        var results = jpaQueryFactory
+        List<ReservationEntity> results = jpaQueryFactory
                 .selectFrom(reservationEntity)
                 .where(
+                        roleCondition,
+                        reservationEntity.deletedAt.isNull(),
                         idEq(id, reservationEntity),
                         userIdEq(userId, reservationEntity),
-                        restaurantIdEq(restaurantId, reservationEntity),
-                        reservationEntity.deletedAt.isNull(),
-                        roleCondition
+                        restaurantIdEq(restaurantId, reservationEntity)
                 )
                 .orderBy(getOrderSpecifier(sort, reservationEntity))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetchResults();
+                .fetch();
 
-        return new PageImpl<>(results.getResults(), pageable, results.getTotal());
+        JPQLQuery<Long> countQuery = jpaQueryFactory
+                .select(reservationEntity.count())
+                .from(reservationEntity)
+                .where(
+                        roleCondition,
+                        reservationEntity.deletedAt.isNull(),
+                        idEq(id, reservationEntity),
+                        userIdEq(userId, reservationEntity),
+                        restaurantIdEq(restaurantId, reservationEntity)
+                );
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+    }
+
+    public Page<ReservationEntity> findReservationPageByDeletedAtIsNullWithOwnerConditions(Pageable pageable, List<Long> restaurantIdListOfOwner, Long userId, Long restaurantId, Long id, String sort) {
+
+        QReservationEntity reservationEntity = QReservationEntity.reservationEntity;
+
+        // Query 실행
+        List<ReservationEntity> results = jpaQueryFactory
+                .selectFrom(reservationEntity)
+                .where(
+                        restaurantIdIn(restaurantIdListOfOwner, reservationEntity),
+                        reservationEntity.deletedAt.isNull(),
+                        idEq(id, reservationEntity),
+                        userIdEq(userId, reservationEntity),
+                        restaurantIdEq(restaurantId, reservationEntity)
+                )
+                .orderBy(getOrderSpecifier(sort, reservationEntity))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPQLQuery<Long> countQuery = jpaQueryFactory
+                .select(reservationEntity.count())
+                .from(reservationEntity)
+                .where(
+                        restaurantIdIn(restaurantIdListOfOwner, reservationEntity),
+                        reservationEntity.deletedAt.isNull(),
+                        idEq(id, reservationEntity),
+                        userIdEq(userId, reservationEntity),
+                        restaurantIdEq(restaurantId, reservationEntity)
+                );
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
     }
 
     // 권한별 조건 메서드
-    private BooleanExpression getRoleCondition(String userRole, Long userId, Long restaurantId) {
+    private BooleanExpression getRoleCondition(String userRole, Long userId) {
         QReservationEntity reservation = QReservationEntity.reservationEntity;
 
         switch (userRole) {
@@ -65,8 +111,6 @@ public class ReservationRepositoryImpl implements ReservationRepository {
                 return null; // 관리자는 모든 데이터를 조회 가능
             case "고객":
                 return reservation.userId.eq(userId); // 고객은 자신의 예약만 조회 가능
-            case "점주":
-                return reservation.restaurantId.eq(restaurantId); // 주인은 자신의 식당 예약만 조회 가능
             default:
                 throw new BadRequestException("유효하지 않은 역할입니다: " + userRole);
         }
@@ -85,8 +129,15 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         return restaurantId != null ? reservationEntity.restaurantId.eq(restaurantId) : null;
     }
 
+    private BooleanExpression restaurantIdIn(List<Long> restaurantIdListOfOwner, QReservationEntity reservationEntity) {
+        return restaurantIdListOfOwner != null && !restaurantIdListOfOwner.isEmpty() ? reservationEntity.restaurantId.in(restaurantIdListOfOwner) : null;
+    }
+
     // 정렬 로직
     private OrderSpecifier<?> getOrderSpecifier(String sort, QReservationEntity reservationEntity) {
+        if (sort == null) {
+            return reservationEntity.createdAt.desc();
+        }
 
         switch (sort) {
             case "SMALLEST":

--- a/src/main/java/com/qring/reservation/infrastructure/util/PassportUtil.java
+++ b/src/main/java/com/qring/reservation/infrastructure/util/PassportUtil.java
@@ -1,0 +1,59 @@
+package com.qring.reservation.infrastructure.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+
+@Component
+public class PassportUtil {
+
+    @Value("${service.jwt.secret-key}")
+    private String secretKey;
+
+    private static Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public static Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(removeBearerPrefix(token))
+                .getBody();
+    }
+
+    private static String removeBearerPrefix(String token) {
+        if (StringUtils.hasText(token) && token.startsWith("Bearer")) {
+            return token.substring(7);
+        }
+        return token;
+    }
+
+    public static Long getUserId(String token) {
+        return extractClaims(token).get("userId", Long.class);
+    }
+
+    public static String getUsername(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    public static String getRole(String token) {
+        return extractClaims(token).get("role", String.class);
+    }
+
+    public static String getSlackEmail(String token) {
+        return extractClaims(token).get("slackEmail", String.class);
+    }
+
+}

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -46,8 +46,8 @@ public class ReservationControllerV1 implements ReservationControllerSwagger {
         );
     }
 
-    @GetMapping("/{reservationId}")
-    public ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@PathVariable Long reservationId) {
+    @GetMapping("/{id}")
+    public ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@PathVariable Long id) {
 
         // 더미데이터 ----------------------------------------------
         ReservationEntity dummyReservationEntity = ReservationEntity.builder()
@@ -70,7 +70,7 @@ public class ReservationControllerV1 implements ReservationControllerSwagger {
     @GetMapping
     public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchBy(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
                                                                       @RequestParam(name = "userId", required = false) Long userId,
-                                                                      @RequestParam(name = "reservationId", required = false) Long reservationId,
+                                                                      @RequestParam(name = "id", required = false) Long id,
                                                                       @RequestParam(name = "restaurantId", required = false) Long restaurantId,
                                                                       @RequestParam(name = "sort", required = false) String sort) {
 
@@ -106,9 +106,9 @@ public class ReservationControllerV1 implements ReservationControllerSwagger {
         );
     }
 
-    @PutMapping("/{reservationId}")
+    @PutMapping("/{id}")
     public ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-User-Id") Long userId,
-                                                @PathVariable Long reservationId,
+                                                @PathVariable Long id,
                                                 @RequestBody PutReservationReqDTOV1 dto) {
 
         return new ResponseEntity<>(
@@ -120,9 +120,9 @@ public class ReservationControllerV1 implements ReservationControllerSwagger {
         );
     }
 
-    @DeleteMapping("/{reservationId}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-User-Id") Long userId,
-                                                   @PathVariable Long reservationId) {
+                                                   @PathVariable Long id) {
 
         return new ResponseEntity<>(
                 ResDTO.builder()

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -4,11 +4,13 @@ import com.qring.reservation.application.global.dto.ResDTO;
 import com.qring.reservation.application.v1.res.ReservationGetByIdResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationSearchResDTOV1;
+import com.qring.reservation.application.v1.service.ReservationServiceV1;
 import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.infrastructure.docs.ReservationControllerSwagger;
 import com.qring.reservation.presentation.v1.req.PostReservationReqDTOV1;
 import com.qring.reservation.presentation.v1.req.PutReservationReqDTOV1;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -21,26 +23,21 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/v1/reservations")
 public class ReservationControllerV1 implements ReservationControllerSwagger {
+
+    private final ReservationServiceV1 reservationServiceV1;
 
     @PostMapping
     public ResponseEntity<ResDTO<ReservationPostResDTOV1>> postBy(@RequestHeader("X-User-Id") Long userId,
                                                                   @Valid@RequestBody PostReservationReqDTOV1 dto) {
 
-        // 더미데이터 ----------------------------------------------
-        ReservationEntity dummyReservationEntity = ReservationEntity.builder()
-                .userId(1L)
-                .restaurantId(501L)
-                .headCount(4)
-                .build();
-        // 추후 삭제 ----------------------------------------------
-
         return new ResponseEntity<>(
                 ResDTO.<ReservationPostResDTOV1>builder()
                         .code(HttpStatus.CREATED.value())
                         .message("예약 생성에 성공했습니다.")
-                        .data(ReservationPostResDTOV1.of(dummyReservationEntity))
+                        .data(reservationServiceV1.postBy(userId, dto))
                         .build(),
                 HttpStatus.CREATED
         );

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -98,9 +98,12 @@ public class ReservationControllerV1 {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-User-Id") Long userId,
+    public ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-User-Role") String userRole,
+                                                @RequestHeader("X-User-Id") Long userId,
                                                 @PathVariable Long id,
                                                 @RequestBody PutReservationReqDTOV1 dto) {
+
+        reservationServiceV1.putBy(userRole, userId, id, dto);
 
         return new ResponseEntity<>(
                 ResDTO.builder()

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -5,22 +5,17 @@ import com.qring.reservation.application.v1.res.ReservationGetByIdResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationPostResDTOV1;
 import com.qring.reservation.application.v1.res.ReservationSearchResDTOV1;
 import com.qring.reservation.application.v1.service.ReservationServiceV1;
-import com.qring.reservation.domain.model.ReservationEntity;
 import com.qring.reservation.infrastructure.docs.ReservationControllerSwagger;
 import com.qring.reservation.presentation.v1.req.PostReservationReqDTOV1;
 import com.qring.reservation.presentation.v1.req.PutReservationReqDTOV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -58,40 +53,55 @@ public class ReservationControllerV1 {
         );
     }
 
-    @GetMapping
-    public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchBy(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-                                                                      @RequestParam(name = "userId", required = false) Long userId,
-                                                                      @RequestParam(name = "id", required = false) Long id,
-                                                                      @RequestParam(name = "restaurantId", required = false) Long restaurantId,
-                                                                      @RequestParam(name = "sort", required = false) String sort) {
-
-        // 더미데이터 ----------------------------------------------
-        List<ReservationEntity> dummyReservations = List.of(
-                ReservationEntity.builder()
-                        .userId(1L)
-                        .restaurantId(501L)
-                        .headCount(4)
-                        .build(),
-                ReservationEntity.builder()
-                        .userId(2L)
-                        .restaurantId(501L)
-                        .headCount(2)
-                        .build(),
-                ReservationEntity.builder()
-                        .userId(1L)
-                        .restaurantId(701L)
-                        .headCount(6)
-                        .build()
-        );
-
-        Page<ReservationEntity> dummyPage = new PageImpl<>(dummyReservations, pageable, dummyReservations.size());
-        // 추후 삭제 ----------------------------------------------
+    @GetMapping("/admin")
+    public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByAdmin(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                           @RequestHeader("X-User-Role") String userRole,
+                                                                           @RequestParam(name = "id", required = false) Long id,
+                                                                           @RequestParam(name = "userId", required = false) Long userId,
+                                                                           @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                           @RequestParam(name = "sort", required = false) String sort) {
 
         return new ResponseEntity<>(
                 ResDTO.<ReservationSearchResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 검색에 성공했습니다.")
-                        .data(ReservationSearchResDTOV1.of(dummyPage))
+                        .data(reservationServiceV1.searchByAdmin(pageable, userRole, id, userId, restaurantId, sort))
+                        .build(),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/customer")
+    public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByCustomer(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                              @RequestHeader("X-User-Role") String userRole,
+                                                                              @RequestHeader("X-User-Id") Long userId,
+                                                                              @RequestParam(name = "id", required = false) Long id,
+                                                                              @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                              @RequestParam(name = "sort", required = false) String sort) {
+
+        return new ResponseEntity<>(
+                ResDTO.<ReservationSearchResDTOV1>builder()
+                        .code(HttpStatus.OK.value())
+                        .message("예약 검색에 성공했습니다.")
+                        .data(reservationServiceV1.searchByCustomer(pageable, userRole, userId, id, restaurantId, sort))
+                        .build(),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/owner")
+    public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByOwner(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                           @RequestHeader("X-User-Role") String userRole,
+                                                                           @RequestParam(name = "id", required = false) Long id,
+                                                                           @RequestParam(name = "userId", required = false) Long userId,
+                                                                           @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                           @RequestParam(name = "sort", required = false) String sort) {
+
+        return new ResponseEntity<>(
+                ResDTO.<ReservationSearchResDTOV1>builder()
+                        .code(HttpStatus.OK.value())
+                        .message("예약 검색에 성공했습니다.")
+                        .data(reservationServiceV1.searchByOwner(pageable, userRole, id, userId, restaurantId, sort))
                         .build(),
                 HttpStatus.OK
         );

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -115,8 +115,11 @@ public class ReservationControllerV1 {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-User-Id") Long userId,
+    public ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-User-Role") String userRole,
+                                                   @RequestHeader("X-User-Id") Long userId,
                                                    @PathVariable Long id) {
+
+        reservationServiceV1.deleteBy(userRole, userId, id);
 
         return new ResponseEntity<>(
                 ResDTO.builder()

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/reservations")
-public class ReservationControllerV1 {
+public class ReservationControllerV1 implements ReservationControllerSwagger {
 
     private final ReservationServiceV1 reservationServiceV1;
 

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -25,7 +25,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/reservations")
-public class ReservationControllerV1 implements ReservationControllerSwagger {
+public class ReservationControllerV1 {
 
     private final ReservationServiceV1 reservationServiceV1;
 
@@ -44,21 +44,15 @@ public class ReservationControllerV1 implements ReservationControllerSwagger {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@PathVariable Long id) {
-
-        // 더미데이터 ----------------------------------------------
-        ReservationEntity dummyReservationEntity = ReservationEntity.builder()
-                .userId(1L)
-                .restaurantId(501L)
-                .headCount(4)
-                .build();
-        // 추후 삭제 ----------------------------------------------
+    public ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@RequestHeader("X-User-Role") String userRole,
+                                                                    @RequestHeader("X-User-Id") Long userId,
+                                                                    @PathVariable Long id) {
 
         return new ResponseEntity<>(
                 ResDTO.<ReservationGetByIdResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 상세 조회에 성공했습니다.")
-                        .data(ReservationGetByIdResDTOV1.of(dummyReservationEntity))
+                        .data(reservationServiceV1.getBy(userRole, userId, id))
                         .build(),
                 HttpStatus.OK
         );

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -64,7 +64,7 @@ public class ReservationControllerV1 {
                 ResDTO.<ReservationSearchResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 검색에 성공했습니다.")
-                        .data(reservationServiceV1.searchByAdmin(pageable, passport, id, userId, restaurantId, sort))
+                        .data(reservationServiceV1.searchByAdmin(pageable, passport, userId, restaurantId, id, sort))
                         .build(),
                 HttpStatus.OK
         );
@@ -81,7 +81,7 @@ public class ReservationControllerV1 {
                 ResDTO.<ReservationSearchResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 검색에 성공했습니다.")
-                        .data(reservationServiceV1.searchByCustomer(pageable, passport, id, restaurantId, sort))
+                        .data(reservationServiceV1.searchByCustomer(pageable, passport, restaurantId, id, sort))
                         .build(),
                 HttpStatus.OK
         );
@@ -91,6 +91,7 @@ public class ReservationControllerV1 {
     public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByOwner(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
                                                                            @RequestHeader("X-Passport-Token") String passport,
                                                                            @RequestParam(name = "userId", required = false) Long userId,
+                                                                           @RequestParam(name = "restaurantId", required = false) Long restaurantId,
                                                                            @RequestParam(name = "id", required = false) Long id,
                                                                            @RequestParam(name = "sort", required = false) String sort) {
 
@@ -98,7 +99,7 @@ public class ReservationControllerV1 {
                 ResDTO.<ReservationSearchResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 검색에 성공했습니다.")
-                        .data(reservationServiceV1.searchByOwner(pageable, passport, userId, id, sort))
+                        .data(reservationServiceV1.searchByOwner(pageable, passport, userId, restaurantId, id, sort))
                         .build(),
                 HttpStatus.OK
         );

--- a/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/controller/ReservationControllerV1.java
@@ -25,29 +25,28 @@ public class ReservationControllerV1 {
     private final ReservationServiceV1 reservationServiceV1;
 
     @PostMapping
-    public ResponseEntity<ResDTO<ReservationPostResDTOV1>> postBy(@RequestHeader("X-User-Id") Long userId,
+    public ResponseEntity<ResDTO<ReservationPostResDTOV1>> postBy(@RequestHeader("X-Passport-Token") String passport,
                                                                   @Valid@RequestBody PostReservationReqDTOV1 dto) {
 
         return new ResponseEntity<>(
                 ResDTO.<ReservationPostResDTOV1>builder()
                         .code(HttpStatus.CREATED.value())
                         .message("예약 생성에 성공했습니다.")
-                        .data(reservationServiceV1.postBy(userId, dto))
+                        .data(reservationServiceV1.postBy(passport, dto))
                         .build(),
                 HttpStatus.CREATED
         );
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@RequestHeader("X-User-Role") String userRole,
-                                                                    @RequestHeader("X-User-Id") Long userId,
+    public ResponseEntity<ResDTO<ReservationGetByIdResDTOV1>> getBy(@RequestHeader("X-Passport-Token") String passport,
                                                                     @PathVariable Long id) {
 
         return new ResponseEntity<>(
                 ResDTO.<ReservationGetByIdResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 상세 조회에 성공했습니다.")
-                        .data(reservationServiceV1.getBy(userRole, userId, id))
+                        .data(reservationServiceV1.getBy(passport, id))
                         .build(),
                 HttpStatus.OK
         );
@@ -55,17 +54,17 @@ public class ReservationControllerV1 {
 
     @GetMapping("/admin")
     public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByAdmin(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-                                                                           @RequestHeader("X-User-Role") String userRole,
-                                                                           @RequestParam(name = "id", required = false) Long id,
+                                                                           @RequestHeader("X-Passport-Token") String passport,
                                                                            @RequestParam(name = "userId", required = false) Long userId,
                                                                            @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                           @RequestParam(name = "id", required = false) Long id,
                                                                            @RequestParam(name = "sort", required = false) String sort) {
 
         return new ResponseEntity<>(
                 ResDTO.<ReservationSearchResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 검색에 성공했습니다.")
-                        .data(reservationServiceV1.searchByAdmin(pageable, userRole, id, userId, restaurantId, sort))
+                        .data(reservationServiceV1.searchByAdmin(pageable, passport, id, userId, restaurantId, sort))
                         .build(),
                 HttpStatus.OK
         );
@@ -73,17 +72,16 @@ public class ReservationControllerV1 {
 
     @GetMapping("/customer")
     public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByCustomer(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-                                                                              @RequestHeader("X-User-Role") String userRole,
-                                                                              @RequestHeader("X-User-Id") Long userId,
-                                                                              @RequestParam(name = "id", required = false) Long id,
+                                                                              @RequestHeader("X-Passport-Token") String passport,
                                                                               @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                              @RequestParam(name = "id", required = false) Long id,
                                                                               @RequestParam(name = "sort", required = false) String sort) {
 
         return new ResponseEntity<>(
                 ResDTO.<ReservationSearchResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 검색에 성공했습니다.")
-                        .data(reservationServiceV1.searchByCustomer(pageable, userRole, userId, id, restaurantId, sort))
+                        .data(reservationServiceV1.searchByCustomer(pageable, passport, id, restaurantId, sort))
                         .build(),
                 HttpStatus.OK
         );
@@ -91,29 +89,27 @@ public class ReservationControllerV1 {
 
     @GetMapping("/owner")
     public ResponseEntity<ResDTO<ReservationSearchResDTOV1>> searchByOwner(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-                                                                           @RequestHeader("X-User-Role") String userRole,
-                                                                           @RequestParam(name = "id", required = false) Long id,
+                                                                           @RequestHeader("X-Passport-Token") String passport,
                                                                            @RequestParam(name = "userId", required = false) Long userId,
-                                                                           @RequestParam(name = "restaurantId", required = false) Long restaurantId,
+                                                                           @RequestParam(name = "id", required = false) Long id,
                                                                            @RequestParam(name = "sort", required = false) String sort) {
 
         return new ResponseEntity<>(
                 ResDTO.<ReservationSearchResDTOV1>builder()
                         .code(HttpStatus.OK.value())
                         .message("예약 검색에 성공했습니다.")
-                        .data(reservationServiceV1.searchByOwner(pageable, userRole, id, userId, restaurantId, sort))
+                        .data(reservationServiceV1.searchByOwner(pageable, passport, userId, id, sort))
                         .build(),
                 HttpStatus.OK
         );
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-User-Role") String userRole,
-                                                @RequestHeader("X-User-Id") Long userId,
+    public ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-Passport-Token") String passport,
                                                 @PathVariable Long id,
                                                 @RequestBody PutReservationReqDTOV1 dto) {
 
-        reservationServiceV1.putBy(userRole, userId, id, dto);
+        reservationServiceV1.putBy(passport, id, dto);
 
         return new ResponseEntity<>(
                 ResDTO.builder()
@@ -125,11 +121,10 @@ public class ReservationControllerV1 {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-User-Role") String userRole,
-                                                   @RequestHeader("X-User-Id") Long userId,
+    public ResponseEntity<ResDTO<Object>> deleteBy(@RequestHeader("X-Passport-Token") String passport,
                                                    @PathVariable Long id) {
 
-        reservationServiceV1.deleteBy(userRole, userId, id);
+        reservationServiceV1.deleteBy(passport, id);
 
         return new ResponseEntity<>(
                 ResDTO.builder()

--- a/src/main/java/com/qring/reservation/presentation/v1/req/PostReservationReqDTOV1.java
+++ b/src/main/java/com/qring/reservation/presentation/v1/req/PostReservationReqDTOV1.java
@@ -16,6 +16,9 @@ public class PostReservationReqDTOV1 {
     @Getter
     public static class Reservation {
 
+        @NotNull(message = "식당 정보를 입력해주세요.")
+        private Long restaurantId;
+
         @Positive(message = "인원 수를 입력해주세요.")
         @Min(value = 1, message = "예약 인원은 최소 1인입니다.")
         @Max(value = 6, message = "예약 인원은 최대 6인입니다.")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,12 @@ spring:
         format_sql: true
     open-in-view: false
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
   config:
     import: classpath:application-key.yml
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,6 +24,10 @@ spring:
   config:
     import: classpath:application-key.yml
 
+service:
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #5

## 📝 Description
- 예약 생성 기능
  - 영업 중인 식당만 예약가능 (구현 예정)
  - 예약 생성 이벤트를 Kafka로 발행 
```
{
    "reservation": {
        "restaurantId" : 10,
        "headCount" : 2
    }
}
-------------------------------------------------
{
    "code": 201,
    "message": "예약 생성에 성공했습니다.",
    "data": {
        "reservation": {
            "id": 663849568780595821,
            "userId": 663760545625626036,
            "restaurantId": 10,
            "status": "CONFIRMED",
            "headCount": 2
        }
    }
}
```
- 예약 상세 조회 기능
  - 관리자는 모든 예약, 고객은 자신의 예약만, 점주는 자신의 식당 예약만 조회 가능
```
{
    "code": 200,
    "message": "예약 상세 조회에 성공했습니다.",
    "data": {
        "reservation": {
            "id": 663849568780595821,
            "userId": 663760545625626036,
            "restaurantId": 10,
            "status": "CONFIRMED",
            "headCount": 2
        }
    }
}
```
- 권한별 예약 검색 기능
  - 관리자는 모든 예약, 고객은 자신의 예약만, 점주는 자신의 식당 예약에서만 검색 가능
- 예약 상태 변경 기능
  - 예약 상태 확인 : 취소 상태인 경우 수정 불가
  - 관리자는 모든 예약, 고객은 자신의 예약만, 점주는 자신의 식당 예약만 상태 변경 가능
```
{
    "reservation": {
        "status" :"취소"
    }
}
-------------------------------------------------
{
    "code": 200,
    "message": "예약 상태 변경에 성공했습니다.",
    "data": null
}

```
- 예약 삭제 기능
  - 대기 상태 확인 : 대기중인 경우 삭제 불가 (구현 예정)
  - 관리자는 모든 예약, 고객은 자신의 예약만, 점주는 자신의 식당 예약만 삭제 가능
 

## 💬 To Reivewers

- 예약 삭제는 예약을 취소하는 로직과는 별개로 예약 내역을 삭제하는 기능으로 생각하고 구현하였습니다. 현재는 권한별로 나누어서 삭제가 가능하도록 하였는데 생각해 보니 예약 내역이니만큼 예약을 생성한 본인만 삭제가 가능하도록 구현하는 것이 맞을까 하는 고민이 생겼는데 다른 분들의 의견이 궁금합니다!
